### PR TITLE
add BaseCoin type to StrategyConfig struct

### DIFF
--- a/sources/global_config.move
+++ b/sources/global_config.move
@@ -45,7 +45,7 @@ module satay::global_config {
     }
 
     /// The strategy configuration
-    struct StrategyConfig<phantom StrategyType> has key {
+    struct StrategyConfig<phantom StrategyType, phantom BaseCoin> has key {
         strategist_address: address,
         keeper_address: address,
         new_strategist_address: address,
@@ -75,10 +75,10 @@ module satay::global_config {
     }
 
     /// Initialize admin contracts when initializing the strategy
-    public(friend) fun initialize_strategy<StrategyType: drop>(governance: &signer) acquires GlobalConfig {
+    public(friend) fun initialize_strategy<StrategyType: drop, BaseCoin>(governance: &signer) acquires GlobalConfig {
         assert_governance(governance);
 
-        move_to(governance, StrategyConfig<StrategyType> {
+        move_to(governance, StrategyConfig<StrategyType, BaseCoin> {
             strategist_address: @satay,
             keeper_address: @satay,
             new_strategist_address: @0x0,
@@ -111,18 +111,18 @@ module satay::global_config {
     }
 
     /// Get strategist address
-    public fun get_strategist_address<StrategyType: drop>(): address acquires StrategyConfig {
-        assert!(exists<StrategyConfig<StrategyType>>(@satay), ERROR_CONFIG_DOES_NOT_EXIST);
+    public fun get_strategist_address<StrategyType: drop, BaseCoin>(): address acquires StrategyConfig {
+        assert!(exists<StrategyConfig<StrategyType, BaseCoin>>(@satay), ERROR_CONFIG_DOES_NOT_EXIST);
 
-        let config = borrow_global<StrategyConfig<StrategyType>>(@satay);
+        let config = borrow_global<StrategyConfig<StrategyType, BaseCoin>>(@satay);
         config.strategist_address
     }
 
     /// Get keeper address
-    public fun get_keeper_address<StrategyType: drop>(): address acquires StrategyConfig {
-        assert!(exists<StrategyConfig<StrategyType>>(@satay), ERROR_CONFIG_DOES_NOT_EXIST);
+    public fun get_keeper_address<StrategyType: drop, BaseCoin>(): address acquires StrategyConfig {
+        assert!(exists<StrategyConfig<StrategyType, BaseCoin>>(@satay), ERROR_CONFIG_DOES_NOT_EXIST);
 
-        let config = borrow_global<StrategyConfig<StrategyType>>(@satay);
+        let config = borrow_global<StrategyConfig<StrategyType, BaseCoin>>(@satay);
         config.keeper_address
     }
 
@@ -166,13 +166,13 @@ module satay::global_config {
         assert!(
             exists<GlobalConfig>(@satay) && 
             exists<VaultConfig<BaseCoin>>(@satay) && 
-            exists<StrategyConfig<StrategyType>>(@satay),
+            exists<StrategyConfig<StrategyType, BaseCoin>>(@satay),
             ERROR_CONFIG_DOES_NOT_EXIST);
 
         let addr = signer::address_of(strategist);
         let global_config = borrow_global<GlobalConfig>(@satay);
         let vault_config = borrow_global<VaultConfig<BaseCoin>>(@satay);
-        let strategy_config = borrow_global<StrategyConfig<StrategyType>>(@satay);
+        let strategy_config = borrow_global<StrategyConfig<StrategyType, BaseCoin>>(@satay);
 
         assert!(
             global_config.governance_address == addr || 
@@ -186,13 +186,13 @@ module satay::global_config {
         assert!(
             exists<GlobalConfig>(@satay) && 
             exists<VaultConfig<BaseCoin>>(@satay) && 
-            exists<StrategyConfig<StrategyType>>(@satay),
+            exists<StrategyConfig<StrategyType, BaseCoin>>(@satay),
             ERROR_CONFIG_DOES_NOT_EXIST);
 
         let addr = signer::address_of(keeper);
         let global_config = borrow_global<GlobalConfig>(@satay);
         let vault_config = borrow_global<VaultConfig<BaseCoin>>(@satay);
-        let strategy_config = borrow_global<StrategyConfig<StrategyType>>(@satay);
+        let strategy_config = borrow_global<StrategyConfig<StrategyType, BaseCoin>>(@satay);
 
         assert!(
             global_config.governance_address == addr || 
@@ -272,17 +272,17 @@ module satay::global_config {
     public entry fun set_strategist<StrategyType: drop, BaseCoin>(strategist: &signer, new_addr: address) acquires GlobalConfig, VaultConfig, StrategyConfig {
         assert_strategist<StrategyType, BaseCoin>(strategist);
 
-        let config = borrow_global_mut<StrategyConfig<StrategyType>>(@satay);
+        let config = borrow_global_mut<StrategyConfig<StrategyType, BaseCoin>>(@satay);
 
         config.new_strategist_address = new_addr;
     }
 
     /// accept new Strategist address
-    public entry fun accept_strategist<StrategyType: drop>(strategist: &signer) acquires StrategyConfig {
-        assert!(exists<StrategyConfig<StrategyType>>(@satay), ERROR_CONFIG_DOES_NOT_EXIST);
+    public entry fun accept_strategist<StrategyType: drop, BaseCoin>(strategist: &signer) acquires StrategyConfig {
+        assert!(exists<StrategyConfig<StrategyType, BaseCoin>>(@satay), ERROR_CONFIG_DOES_NOT_EXIST);
 
         let new_addr = signer::address_of(strategist);
-        let config = borrow_global_mut<StrategyConfig<StrategyType>>(@satay);
+        let config = borrow_global_mut<StrategyConfig<StrategyType, BaseCoin>>(@satay);
 
         assert!(config.new_strategist_address == new_addr, ERR_NOT_MANAGER);
 
@@ -294,17 +294,17 @@ module satay::global_config {
     public entry fun set_keeper<StrategyType: drop, BaseCoin>(keeper: &signer, new_addr: address) acquires GlobalConfig, VaultConfig, StrategyConfig {
         assert_keeper<StrategyType, BaseCoin>(keeper);
 
-        let config = borrow_global_mut<StrategyConfig<StrategyType>>(@satay);
+        let config = borrow_global_mut<StrategyConfig<StrategyType, BaseCoin>>(@satay);
 
         config.new_keeper_address = new_addr;
     }
 
     /// accept new Keeper address
-    public entry fun accept_keeper<StrategyType: drop>(keeper: &signer) acquires StrategyConfig {
-        assert!(exists<StrategyConfig<StrategyType>>(@satay), ERROR_CONFIG_DOES_NOT_EXIST);
+    public entry fun accept_keeper<StrategyType: drop, BaseCoin>(keeper: &signer) acquires StrategyConfig {
+        assert!(exists<StrategyConfig<StrategyType, BaseCoin>>(@satay), ERROR_CONFIG_DOES_NOT_EXIST);
 
         let new_addr = signer::address_of(keeper);
-        let config = borrow_global_mut<StrategyConfig<StrategyType>>(@satay);
+        let config = borrow_global_mut<StrategyConfig<StrategyType, BaseCoin>>(@satay);
 
         assert!(config.new_keeper_address == new_addr, ERR_NOT_MANAGER);
 

--- a/sources/satay.move
+++ b/sources/satay.move
@@ -133,14 +133,14 @@ module satay::satay {
     // called by strategies
 
     // allows Strategy to get VaultCapability of vault_id of manager_addr
-    public(friend) fun approve_strategy<StrategyType: drop>(
+    public(friend) fun approve_strategy<StrategyType: drop, BaseCoin>(
         governance: &signer,
         vault_id: u64,
         position_coin_type: TypeInfo,
         debt_ratio: u64
     ) acquires ManagerAccount {
         global_config::assert_governance(governance);
-        global_config::initialize_strategy<StrategyType>(governance);
+        global_config::initialize_strategy<StrategyType, BaseCoin>(governance);
 
         let manager_addr = signer::address_of(governance);
         assert_manager_initialized(manager_addr);

--- a/sources/strategies/base_strategy.move
+++ b/sources/strategies/base_strategy.move
@@ -18,7 +18,7 @@ module satay::base_strategy {
     const ERR_DEBT_OUT_STANDING: u64 = 304;
 
     // initialize vault_id to accept strategy
-    public fun initialize<StrategyType: drop, StrategyCoin>(
+    public fun initialize<StrategyType: drop, StrategyCoin, BaseCoin>(
         governance: &signer,
         vault_id: u64,
         debt_ratio: u64,
@@ -26,7 +26,7 @@ module satay::base_strategy {
     ) {
 
         // approve strategy on vault
-        satay::approve_strategy<StrategyType>(
+        satay::approve_strategy<StrategyType, BaseCoin>(
             governance,
             vault_id, 
             type_info::type_of<StrategyCoin>(), 
@@ -384,7 +384,7 @@ module satay::base_strategy {
     }
 
     // migrate to new strategy
-    public fun migrate_from<OldStrategy: drop, NewStrategy: drop, NewStrategyCoin>(
+    public fun migrate_from<OldStrategy: drop, NewStrategy: drop, NewStrategyCoin, BaseCoin>(
         governance: &signer,
         manager_addr: address,
         vault_id: u64,
@@ -398,7 +398,7 @@ module satay::base_strategy {
             0
         );
 
-        initialize<NewStrategy, NewStrategyCoin>(
+        initialize<NewStrategy, NewStrategyCoin, BaseCoin>(
             governance,
             vault_id,
             debt_ratio,

--- a/sources/strategies/ditto_farming_strategy.move
+++ b/sources/strategies/ditto_farming_strategy.move
@@ -27,7 +27,7 @@ module satay::ditto_farming_strategy {
         debt_ratio: u64
     ) {
         // initialize through base_strategy_module
-        base_strategy::initialize<DittoStrategy, DittoFarmingCoin>(
+        base_strategy::initialize<DittoStrategy, DittoFarmingCoin, AptosCoin>(
             governance,
             vault_id,
             debt_ratio,

--- a/tests/test_satay.move
+++ b/tests/test_satay.move
@@ -132,7 +132,7 @@ module satay::test_satay {
 
         satay::new_vault<USDT>(&vault_manager, manager_addr, b"USDT vault", 200, 5000);
 
-        base_strategy::initialize<TestStrategy, USDT>(&vault_manager, 0, 1000, TestStrategy {});
+        base_strategy::initialize<TestStrategy, USDT, USDT>(&vault_manager, 0, 1000, TestStrategy {});
         assert!(satay::has_strategy<TestStrategy>(&vault_manager, 0), 3);
     }
 
@@ -150,9 +150,9 @@ module satay::test_satay {
         satay::new_vault<USDT>(&vault_manager, manager_addr, b"USDT vault", 200, 5000);
 
         set_time_has_started_for_testing(&aptos_framework);
-        base_strategy::initialize<TestStrategy, USDT>(&vault_manager, 0, 1000, TestStrategy {});
+        base_strategy::initialize<TestStrategy, USDT, USDT>(&vault_manager, 0, 1000, TestStrategy {});
         assert!(satay::has_strategy<TestStrategy>(&vault_manager, 0), 3);
-        base_strategy::initialize<TestStrategy2, USDT>(&vault_manager, 0, 1000, TestStrategy2 {});
+        base_strategy::initialize<TestStrategy2, USDT, USDT>(&vault_manager, 0, 1000, TestStrategy2 {});
         assert!(satay::has_strategy<TestStrategy2>(&vault_manager, 0), 3);
 
     }
@@ -171,7 +171,7 @@ module satay::test_satay {
 
         satay::new_vault<USDT>(&vault_manager, manager_addr, b"USDT vault", 200, 5000);
 
-        base_strategy::initialize<TestStrategy, USDT>(&vault_manager, 0, 1000, TestStrategy {});
+        base_strategy::initialize<TestStrategy, USDT, USDT>(&vault_manager, 0, 1000, TestStrategy {});
         let (vault_cap, vault_lock) = satay::lock_vault<TestStrategy>(
             manager_addr,
             0,
@@ -198,8 +198,8 @@ module satay::test_satay {
 
         satay::new_vault<USDT>(&vault_manager, manager_addr, b"USDT vault", 200, 5000);
 
-        base_strategy::initialize<TestStrategy, USDT>(&vault_manager, 0, 1000, TestStrategy {});
-        base_strategy::initialize<TestStrategy2, USDT>(&vault_manager, 0, 1000, TestStrategy2 {});
+        base_strategy::initialize<TestStrategy, USDT, USDT>(&vault_manager, 0, 1000, TestStrategy {});
+        base_strategy::initialize<TestStrategy2, USDT, USDT>(&vault_manager, 0, 1000, TestStrategy2 {});
         let (vault_cap, vault_lock) = satay::lock_vault<TestStrategy>(
             signer::address_of(&vault_manager),
             0,

--- a/tests/test_simple_staking_strategy.move
+++ b/tests/test_simple_staking_strategy.move
@@ -74,7 +74,7 @@ module satay::test_simple_staking_strategy {
         let manager_addr = signer::address_of(manager_acc);
 
         satay::new_vault<USDT>(manager_acc, manager_addr, b"aptos_vault", 200, 5000);
-        mock_simple_staking_strategy::initialize(manager_acc, 0, 1000);
+        mock_simple_staking_strategy::initialize<USDT>(manager_acc, 0, 1000);
         coins::mint_coin<USDT>(token_admin, signer::address_of(user), 100);
         satay::deposit<USDT>(user, signer::address_of(manager_acc), 0, 100);
         staking_pool::initialize<USDT, AptosCoin>(staking_pool_admin);

--- a/tests/test_strategies/mock_ditto_farming_strategy.move
+++ b/tests/test_strategies/mock_ditto_farming_strategy.move
@@ -28,7 +28,7 @@ module satay::mock_ditto_farming_strategy {
         debt_ratio: u64
     ) {
         // initialize through base_strategy_module
-        base_strategy::initialize<DittoStrategy, DittoFarmingCoin>(
+        base_strategy::initialize<DittoStrategy, DittoFarmingCoin, AptosCoin>(
             governance,
             vault_id,
             debt_ratio,

--- a/tests/test_strategies/mock_simple_staking_strategy.move
+++ b/tests/test_strategies/mock_simple_staking_strategy.move
@@ -13,12 +13,12 @@ module satay::mock_simple_staking_strategy {
     struct SimpleStakingStrategy has drop {}
 
     // initialize vault_id to accept strategy
-    public entry fun initialize(
+    public entry fun initialize<BaseCoin>(
         governance: &signer,
         vault_id: u64,
         debt_ratio: u64
     ) {
-        base_strategy::initialize<SimpleStakingStrategy, StakingCoin>(
+        base_strategy::initialize<SimpleStakingStrategy, StakingCoin, BaseCoin>(
             governance,
             vault_id,
             debt_ratio,

--- a/tests/test_user_workflow.move
+++ b/tests/test_user_workflow.move
@@ -76,7 +76,7 @@ module satay::test_user_workflow {
         let manager_addr = signer::address_of(manager_acc);
 
         satay::new_vault<USDT>(manager_acc, manager_addr, b"aptos_vault", 200, 5000);
-        mock_simple_staking_strategy::initialize(manager_acc, 0, 10000);
+        mock_simple_staking_strategy::initialize<USDT>(manager_acc, 0, 10000);
         staking_pool::initialize<USDT, AptosCoin>(manager_acc);
         staking_pool::deposit_rewards<AptosCoin>(user, 10000);
     }


### PR DESCRIPTION
I think the BaseCoin type is needed on the StrategyConfig struct as vaults with different BaseCoins may approve the same strategy. The example that comes to mind: two stable coin vaults which both use the borrow APY optimization strategy.