### PR TITLE
delegate create resource account on ditto strategy to deployer, not governor

### DIFF
--- a/strategies/ditto-farming-strategy/sources/ditto_farming_strategy.move
+++ b/strategies/ditto-farming-strategy/sources/ditto_farming_strategy.move
@@ -10,7 +10,8 @@ module satay_ditto_farming_strategy::ditto_farming_strategy {
     use satay::vault::VaultCapability;
 
     use satay_ditto_farming::ditto_farming::{Self, DittoFarmingCoin};
-    use satay::global_config;
+
+    const ERR_NOT_AUTHORIZED: u64 = 1;
 
     // witness for the strategy
     // used for checking approval when locking and unlocking vault
@@ -19,6 +20,21 @@ module satay_ditto_farming_strategy::ditto_farming_strategy {
     // needed to store residual aptos during harvest
     struct DittoStrategyAccount has key {
         signer_cap: SignerCapability
+    }
+
+    // create resource account to store residual aptos during harvest
+    public entry fun create_ditto_strategy_account(
+        satay_ditto_famring_strategy: &signer
+    ) {
+        assert!(signer::address_of(satay_ditto_famring_strategy) == @satay_ditto_farming_strategy, ERR_NOT_AUTHORIZED);
+        let (strategy_account, signer_cap) = account::create_resource_account(
+            satay_ditto_famring_strategy,
+            b"ditto strategy account",
+        );
+        move_to(satay_ditto_famring_strategy, DittoStrategyAccount {
+            signer_cap
+        });
+        coin::register<AptosCoin>(&strategy_account);
     }
 
     // initialize vault_id to accept strategy
@@ -34,17 +50,6 @@ module satay_ditto_farming_strategy::ditto_farming_strategy {
             debt_ratio,
             DittoStrategy {}
         );
-
-        // create resource account to store residual aptos during harvest
-        let (strategy_account, signer_cap) = account::create_resource_account(
-            governance,
-            b"ditto strategy account",
-        );
-        move_to(governance, DittoStrategyAccount {
-            signer_cap
-        });
-        coin::register<AptosCoin>(&strategy_account);
-
     }
 
     // harvests the Strategy, realizing any profits or losses and adjusting the Strategy's position.
@@ -61,9 +66,7 @@ module satay_ditto_farming_strategy::ditto_farming_strategy {
             DittoStrategy {}
         );
 
-        // TODO: what happens if the governor address is changed?
-        let governor_addr = global_config::get_governance_address();
-        let ditto_strategy_cap = borrow_global_mut<DittoStrategyAccount>(governor_addr);
+        let ditto_strategy_cap = borrow_global_mut<DittoStrategyAccount>(@satay_ditto_farming_strategy);
         let ditto_strategy_signer = account::create_signer_with_capability(&ditto_strategy_cap.signer_cap);
         let ditto_strategy_addr = signer::address_of(&ditto_strategy_signer);
 
@@ -148,7 +151,7 @@ module satay_ditto_farming_strategy::ditto_farming_strategy {
         // deploy to_apply AptosCoin to ditto_farming structured product
         let (ditto_strategy_coins, residual) = ditto_farming::apply_position(
             to_apply,
-            governor_addr,
+            @satay_ditto_farming_strategy,
         );
         // store residual amount on strategy account
         coin::deposit(ditto_strategy_addr, residual);
@@ -196,8 +199,7 @@ module satay_ditto_farming_strategy::ditto_farming_strategy {
             DittoStrategy {}
         );
 
-        let governor_addr = global_config::get_governance_address();
-        let ditto_strategy_account = borrow_global_mut<DittoStrategyAccount>(governor_addr);
+        let ditto_strategy_account = borrow_global_mut<DittoStrategyAccount>(@satay_ditto_farming_strategy);
         let ditto_strategy_addr = account::get_signer_capability_address(&ditto_strategy_account.signer_cap);
 
         let (
@@ -232,8 +234,7 @@ module satay_ditto_farming_strategy::ditto_farming_strategy {
             DittoStrategy {}
         );
 
-        let governor_addr = global_config::get_governance_address();
-        let ditto_strategy_account = borrow_global_mut<DittoStrategyAccount>(governor_addr);
+        let ditto_strategy_account = borrow_global_mut<DittoStrategyAccount>(@satay_ditto_farming_strategy);
         let ditto_strategy_signer = account::create_signer_with_capability(&ditto_strategy_account.signer_cap);
         let ditto_strategy_addr = signer::address_of(&ditto_strategy_signer);
 

--- a/strategies/ditto-farming-strategy/tests/mock_ditto_farming_strategy.move
+++ b/strategies/ditto-farming-strategy/tests/mock_ditto_farming_strategy.move
@@ -11,7 +11,8 @@ module satay_ditto_farming_strategy::mock_ditto_farming_strategy {
     use satay::vault::VaultCapability;
 
     use satay_ditto_farming::mock_ditto_farming::{Self, DittoFarmingCoin};
-    use satay::global_config;
+
+    const ERR_NOT_AUTHORIZED: u64 = 1;
 
     // witness for the strategy
     // used for checking approval when locking and unlocking vault
@@ -20,6 +21,21 @@ module satay_ditto_farming_strategy::mock_ditto_farming_strategy {
     // needed to store residual aptos during harvest
     struct DittoStrategyAccount has key {
         signer_cap: SignerCapability
+    }
+
+    // create resource account to store residual aptos during harvest
+    public entry fun create_ditto_strategy_account(
+        satay_ditto_famring_strategy: &signer
+    ) {
+        assert!(signer::address_of(satay_ditto_famring_strategy) == @satay_ditto_farming_strategy, ERR_NOT_AUTHORIZED);
+        let (strategy_account, signer_cap) = account::create_resource_account(
+            satay_ditto_famring_strategy,
+            b"ditto strategy account",
+        );
+        move_to(satay_ditto_famring_strategy, DittoStrategyAccount {
+            signer_cap
+        });
+        coin::register<AptosCoin>(&strategy_account);
     }
 
     // initialize vault_id to accept strategy
@@ -35,17 +51,6 @@ module satay_ditto_farming_strategy::mock_ditto_farming_strategy {
             debt_ratio,
             DittoStrategy {}
         );
-
-        // create resource account to store residual aptos during harvest
-        let (strategy_account, signer_cap) = account::create_resource_account(
-            governance,
-            b"ditto strategy account",
-        );
-        move_to(governance, DittoStrategyAccount {
-            signer_cap
-        });
-        coin::register<AptosCoin>(&strategy_account);
-
     }
 
     // harvests the Strategy, realizing any profits or losses and adjusting the Strategy's position.
@@ -62,9 +67,7 @@ module satay_ditto_farming_strategy::mock_ditto_farming_strategy {
             DittoStrategy {}
         );
 
-        // TODO: what happens if the governor address is changed?
-        let governor_addr = global_config::get_governance_address();
-        let ditto_strategy_cap = borrow_global_mut<DittoStrategyAccount>(governor_addr);
+        let ditto_strategy_cap = borrow_global_mut<DittoStrategyAccount>(@satay_ditto_farming_strategy);
         let ditto_strategy_signer = account::create_signer_with_capability(&ditto_strategy_cap.signer_cap);
         let ditto_strategy_addr = signer::address_of(&ditto_strategy_signer);
 
@@ -149,7 +152,7 @@ module satay_ditto_farming_strategy::mock_ditto_farming_strategy {
         // deploy to_apply AptosCoin to ditto_farming structured product
         let (ditto_strategy_coins, residual) = mock_ditto_farming::apply_position(
             to_apply,
-            governor_addr,
+            @satay_ditto_farming_strategy,
         );
         // store residual amount on strategy account
         coin::deposit(ditto_strategy_addr, residual);
@@ -197,8 +200,7 @@ module satay_ditto_farming_strategy::mock_ditto_farming_strategy {
             DittoStrategy {}
         );
 
-        let governor_addr = global_config::get_governance_address();
-        let ditto_strategy_account = borrow_global_mut<DittoStrategyAccount>(governor_addr);
+        let ditto_strategy_account = borrow_global_mut<DittoStrategyAccount>(@satay_ditto_farming_strategy);
         let ditto_strategy_addr = account::get_signer_capability_address(&ditto_strategy_account.signer_cap);
 
         let (
@@ -233,8 +235,7 @@ module satay_ditto_farming_strategy::mock_ditto_farming_strategy {
             DittoStrategy {}
         );
 
-        let governor_addr = global_config::get_governance_address();
-        let ditto_strategy_account = borrow_global_mut<DittoStrategyAccount>(governor_addr);
+        let ditto_strategy_account = borrow_global_mut<DittoStrategyAccount>(@satay_ditto_farming_strategy);
         let ditto_strategy_signer = account::create_signer_with_capability(&ditto_strategy_account.signer_cap);
         let ditto_strategy_addr = signer::address_of(&ditto_strategy_signer);
 

--- a/strategies/ditto-farming-strategy/tests/test_ditto_strategy.move
+++ b/strategies/ditto-farming-strategy/tests/test_ditto_strategy.move
@@ -36,6 +36,7 @@ module satay_ditto_farming_strategy::test_ditto_strategy {
         manager_acc: &signer,
         ditto_farming: &signer,
         ditto_staking: &signer,
+        ditto_farming_strategy: &signer,
         user: &signer
     ) {
         stake::initialize_for_test(aptos_framework);
@@ -74,6 +75,7 @@ module satay_ditto_farming_strategy::test_ditto_strategy {
 
         aptos_coin::mint(aptos_framework, user_address, DEPOSIT_AMOUNT);
         mock_ditto_farming::initialize(ditto_farming);
+        mock_ditto_farming_strategy::create_ditto_strategy_account(ditto_farming_strategy);
         mock_ditto_farming_strategy::initialize(manager_acc, 0, 5000);
     }
 
@@ -85,6 +87,7 @@ module satay_ditto_farming_strategy::test_ditto_strategy {
         manager_acc: &signer,
         ditto_farming: &signer,
         ditto_staking: &signer,
+        ditto_farming_strategy: &signer,
         user: &signer
     ) {
         test_account::create_account(ditto_staking);
@@ -97,6 +100,7 @@ module satay_ditto_farming_strategy::test_ditto_strategy {
             manager_acc,
             ditto_farming,
             ditto_staking,
+            ditto_farming_strategy,
             user
         );
     }
@@ -113,6 +117,7 @@ module satay_ditto_farming_strategy::test_ditto_strategy {
         manager_acc = @satay,
         ditto_farming = @satay_ditto_farming,
         ditto_staking = @ditto_staking,
+        ditto_farming_strategy = @satay_ditto_farming_strategy,
         user = @0x45,
         userB = @0x46
     )]
@@ -123,10 +128,20 @@ module satay_ditto_farming_strategy::test_ditto_strategy {
         manager_acc: &signer,
         ditto_farming: &signer,
         ditto_staking: &signer,
+        ditto_farming_strategy: &signer,
         user: &signer,
         userB: &signer
     ) {
-        setup_strategy_vault(aptos_framework, pool_owner, pool_account, manager_acc, ditto_farming, ditto_staking, user);
+        setup_strategy_vault(
+            aptos_framework,
+            pool_owner,
+            pool_account,
+            manager_acc,
+            ditto_farming,
+            ditto_staking,
+            ditto_farming_strategy,
+            user
+        );
         test_account::create_account(userB);
 
         let vault_address = satay::get_vault_address_by_id(0);
@@ -147,6 +162,7 @@ module satay_ditto_farming_strategy::test_ditto_strategy {
         manager_acc = @satay,
         ditto_farming = @satay_ditto_farming,
         ditto_staking = @ditto_staking,
+        ditto_farming_strategy = @satay_ditto_farming_strategy,
         user = @0x45,
         userB = @0x46
     )]
@@ -157,10 +173,20 @@ module satay_ditto_farming_strategy::test_ditto_strategy {
         manager_acc: &signer,
         ditto_farming: &signer,
         ditto_staking: &signer,
+        ditto_farming_strategy: &signer,
         user: &signer,
         userB: &signer
     ) {
-        setup_strategy_vault(aptos_framework, pool_owner, pool_account, manager_acc, ditto_farming, ditto_staking, user);
+        setup_strategy_vault(
+            aptos_framework,
+            pool_owner,
+            pool_account,
+            manager_acc,
+            ditto_farming,
+            ditto_staking,
+            ditto_farming_strategy,
+            user
+        );
         test_account::create_account(userB);
 
         let vault_address = satay::get_vault_address_by_id(0);


### PR DESCRIPTION
In the case that the governor changes, the strategy account will be lost. In this build, the strategy deployer will call create_ditto_strategy_account to create the resource account and the capability will be stored in that account.